### PR TITLE
Make py2 classifiers optional

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -29,5 +29,7 @@
     "cov_fail_under": "100",
     "dictionary": "en_AU",
     "python_requires": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    "python_versions": "2.7 3.4 3.5 3.6 3.7"
+    "python_versions": "2.7 3.4 3.5 3.6 3.7",
+    "classifier_pytwo": "Programming Language :: Python :: 2",
+    "classifier_pytwoseven": "Programming Language :: Python :: 2.7"
 }

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.docker_application_dirname}}/setup.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.docker_application_dirname}}/setup.py
@@ -76,11 +76,11 @@ setup(
         if elem
     ],
     url='{{ cookiecutter.project_url }}',
-    classifiers=[
+    classifiers=[elem for elem in [
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        '{{ cookiecutter.classifier_pytwo }}', 'Programming Language :: Python :: 2',
+        '{{ cookiecutter.classifier_pytwoseven }}', 'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
@@ -90,5 +90,5 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-    ],
+    ] if elem],
 )

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.docker_application_dirname}}/setup.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.docker_application_dirname}}/setup.py
@@ -79,8 +79,8 @@ setup(
     classifiers=[elem for elem in [
         'Development Status :: 4 - Beta',
         'Programming Language :: Python',
-        '{{ cookiecutter.classifier_pytwo }}', 'Programming Language :: Python :: 2',
-        '{{ cookiecutter.classifier_pytwoseven }}', 'Programming Language :: Python :: 2.7',
+        '{{ cookiecutter.classifier_pytwo }}',
+        '{{ cookiecutter.classifier_pytwoseven }}',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
<!--
Thank you for your contribution to the cookiecutter-3amigos-py repository.
Your code will need to pass the automated checks before merging.
Before submitting this PR, please make sure the follow checks are done if
applicable, also if they are applicable move them out of this comment into the
main PR text body:
- [x] Unit tests added
- [x] Documentations updated with the change
- [x] Towncrier news fragment added
-->
