### PR TITLE
Restore  pylint config with 88 line length

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.docker_application_dirname}}/.pylintrc
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.docker_application_dirname}}/.pylintrc
@@ -91,7 +91,7 @@ score=yes
 [REFACTORING]
 
 # Maximum number of nested blocks for function / method body
-max-nested-blocks=8
+max-nested-blocks=5
 
 # Complete name of functions that never returns. When checking for
 # inconsistent-return-statements if a never returning function is called then
@@ -433,19 +433,19 @@ known-third-party=enchant
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=8
+max-args=5
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=12
+max-attributes=7
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5
 
 # Maximum number of branch for function / method body
-max-branches=40
+max-branches=12
 
 # Maximum number of locals for function / method body
-max-locals=20
+max-locals=15
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7
@@ -457,10 +457,10 @@ max-public-methods=20
 max-returns=6
 
 # Maximum number of statements in function / method body
-max-statements=80
+max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=0
+min-public-methods=2
 
 
 [EXCEPTIONS]

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.docker_application_dirname}}/.pylintrc
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.docker_application_dirname}}/.pylintrc
@@ -91,7 +91,7 @@ score=yes
 [REFACTORING]
 
 # Maximum number of nested blocks for function / method body
-max-nested-blocks=5
+max-nested-blocks=8
 
 # Complete name of functions that never returns. When checking for
 # inconsistent-return-statements if a never returning function is called then
@@ -433,19 +433,19 @@ known-third-party=enchant
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+max-args=8
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=12
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5
 
 # Maximum number of branch for function / method body
-max-branches=12
+max-branches=40
 
 # Maximum number of locals for function / method body
-max-locals=15
+max-locals=20
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7
@@ -457,10 +457,10 @@ max-public-methods=20
 max-returns=6
 
 # Maximum number of statements in function / method body
-max-statements=50
+max-statements=80
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=0
 
 
 [EXCEPTIONS]


### PR DESCRIPTION
<!--
Thank you for your contribution to the cookiecutter-3amigos-py repository.
Your code will need to pass the automated checks before merging.
Before submitting this PR, please make sure the follow checks are done if
applicable, also if they are applicable move them out of this comment into the
main PR text body:
- [x] Unit tests added
- [x] Documentations updated with the change
- [x] Towncrier news fragment added
-->
