### PR TITLE
Make isort config black compatible

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.docker_application_dirname}}/.isort.cfg
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.docker_application_dirname}}/.isort.cfg
@@ -1,3 +1,5 @@
-[isort]
-not_skip = __init__.py
-line_length = 88
+[settings]
+not_skip=__init__.py
+line_length=88
+multi_line_output=3
+include_trailing_comma=yes


### PR DESCRIPTION
<!--
Thank you for your contribution to the cookiecutter-3amigos-py repository.
Your code will need to pass the automated checks before merging.
Before submitting this PR, please make sure the follow checks are done if
applicable, also if they are applicable move them out of this comment into the
main PR text body:
- [x] Unit tests added
- [x] Documentations updated with the change
- [x] Towncrier news fragment added
-->
